### PR TITLE
Added custom validator in user schema to ensure uniqueness of email

### DIFF
--- a/server/src/models/userModel.js
+++ b/server/src/models/userModel.js
@@ -10,8 +10,8 @@ const userSchema = new Schema(
     },
     email: {
       type: String,
-      // unique: true,
       lowercase: true,
+      match: [/(.+)@(.+){2,}\.(.+){2,}/, "Please enter a valid email"],
       validate: {
         validator: async function (email) {
           const user = await this.constructor.findOne({ email });

--- a/server/src/models/userModel.js
+++ b/server/src/models/userModel.js
@@ -10,7 +10,22 @@ const userSchema = new Schema(
     },
     email: {
       type: String,
-      required: true,
+      // unique: true,
+      lowercase: true,
+      validate: {
+        validator: async function (email) {
+          const user = await this.constructor.findOne({ email });
+          if (user) {
+            if (this.id === user.id) {
+              return true;
+            }
+            return false;
+          }
+          return true;
+        },
+        message: () => "Email address already registered.",
+      },
+      required: [true, "User email required"],
     },
     postalCode: {
       type: String,


### PR DESCRIPTION
Hi. I have added a custom validator to check for unique email in user schema. There were two approaches to this:

1. Using `unique` option in mongoose: This approach would basically create a MongoDB index over email field and check the property for uniqueness. But the shortcoming of this approach is that the index must be created on the database for this to work. If index is not created, unique would not work. This is pointed out [here](https://mongoosejs.com/docs/validation.html#the-unique-option-is-not-a-validator).
2. Custom validator: Write a custom validator which searches the DB for documents using the email field and, if found, returns false. This is the approach I have used. 

Also, currently there is no pattern to match whether the string entered is actually an email. I think there should be a check on the backend to ensure whether the string entered is actually an email address, and the user has the ownership of that email. These two things can be accomplished by sending a code to the user's email and validating it on the backend. This way, validity of email and its ownership can be established. 

As of now, I have added a simple regex pattern to check whether the entered string is actually an email. But there has already been a lot of debate around this and the consensus is that regex is not the best way to do it. 

Maybe you can include email validation in future scope of work.  