### PR TITLE
Add BottomNavigation component

### DIFF
--- a/client/src/components/BottomNavigation/BottomNavigation.js
+++ b/client/src/components/BottomNavigation/BottomNavigation.js
@@ -2,10 +2,12 @@ import * as React from "react";
 // Ui components
 import { BottomNavigation, BottomNavigationAction } from "@mui/material";
 // Icons
-import FolderIcon from "@mui/icons-material/Folder";
-import RestoreIcon from "@mui/icons-material/Restore";
-import FavoriteIcon from "@mui/icons-material/Favorite";
-import LocationOnIcon from "@mui/icons-material/LocationOn";
+import {
+  Folder as FolderIcon,
+  Restore as RestoreIcon,
+  Favorite as FavoriteIcon,
+  LocationOn as LocationOnIcon,
+} from "@mui/icons-material";
 
 export default function LabelBottomNavigation() {
   const [value, setValue] = React.useState("recents");

--- a/client/src/components/BottomNavigation/BottomNavigation.js
+++ b/client/src/components/BottomNavigation/BottomNavigation.js
@@ -7,7 +7,7 @@ import RestoreIcon from "@mui/icons-material/Restore";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 
-export default function BottomNavigation() {
+export default function LabelBottomNavigation() {
   const [value, setValue] = React.useState("recents");
 
   const handleChange = (event, newValue) => {

--- a/client/src/components/BottomNavigation/BottomNavigation.js
+++ b/client/src/components/BottomNavigation/BottomNavigation.js
@@ -1,0 +1,41 @@
+import * as React from "react";
+// Ui components
+import { BottomNavigation, BottomNavigationAction } from "@mui/material";
+// Icons
+import FolderIcon from "@mui/icons-material/Folder";
+import RestoreIcon from "@mui/icons-material/Restore";
+import FavoriteIcon from "@mui/icons-material/Favorite";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+
+export default function LabelBottomNavigation() {
+  const [value, setValue] = React.useState("recents");
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <BottomNavigation sx={{ width: 500 }} value={value} onChange={handleChange}>
+      <BottomNavigationAction
+        label="Recents"
+        value="recents"
+        icon={<RestoreIcon />}
+      />
+      <BottomNavigationAction
+        label="Favorites"
+        value="favorites"
+        icon={<FavoriteIcon />}
+      />
+      <BottomNavigationAction
+        label="Nearby"
+        value="nearby"
+        icon={<LocationOnIcon />}
+      />
+      <BottomNavigationAction
+        label="Folder"
+        value="folder"
+        icon={<FolderIcon />}
+      />
+    </BottomNavigation>
+  );
+}

--- a/client/src/components/BottomNavigation/BottomNavigation.js
+++ b/client/src/components/BottomNavigation/BottomNavigation.js
@@ -7,7 +7,7 @@ import RestoreIcon from "@mui/icons-material/Restore";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 
-export default function LabelBottomNavigation() {
+export default function BottomNavigation() {
   const [value, setValue] = React.useState("recents");
 
   const handleChange = (event, newValue) => {

--- a/client/src/components/BottomNavigationBar/BottomNavigationBar.js
+++ b/client/src/components/BottomNavigationBar/BottomNavigationBar.js
@@ -9,7 +9,7 @@ import {
   LocationOn as LocationOnIcon,
 } from "@mui/icons-material";
 
-export default function LabelBottomNavigation() {
+export default function BottomNavigationBar() {
   const [value, setValue] = React.useState("recents");
 
   const handleChange = (event, newValue) => {


### PR DESCRIPTION
### This PR closes the following issue:

- [Issue #129](https://github.com/lugenx/ecohabit/issues/129)

### Changes made:

**1. Regarding the issue**

  - Added `BottomNavigation` folder inside `client/src/components`
  - Added `BottomNavigation.js` file inside `client/src/components/BottomNavigation`
  - Replicated "Bottom navigation with no label" demo from MUI docs
  - Organized imports

**2. Additional changes**

  - Renamed `LabelBottomNavigation()` component to `BottomNavigation()`
    > The task was to copy the demo _**as is**_. I decided to rename the component name from demo to match the file and the folder names to keep naming consistent in the project.
