### PR TITLE
Email and password validation Issue #185

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^6.7.3",
-        "node-fetch": "^3.3.0"
+        "node-fetch": "^3.3.0",
+        "validator": "^13.9.0"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -2658,6 +2659,14 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4776,6 +4785,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "optional": true
+    },
+    "validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^6.7.3",
-    "node-fetch": "^3.3.0"
+    "node-fetch": "^3.3.0",
+    "validator": "^13.9.0"
   },
   "type": "module"
 }

--- a/server/src/controller/userController.js
+++ b/server/src/controller/userController.js
@@ -53,7 +53,7 @@ const userSignUp = async (req, res) => {
   if (!isValidPassword) {
     return res.status(400).json({
       error:
-        "Password not strong enough. A strong password is minimum 8 characters long containing at least 1 number and 1 special character.",
+        "Please choose a stronger password that is at least 8 characters long and includes a mix of letters, numbers, and symbols.",
     });
   }
 

--- a/server/src/controller/userController.js
+++ b/server/src/controller/userController.js
@@ -42,14 +42,19 @@ const userSignUp = async (req, res) => {
   }
 
   // Validate the password
-  const isValidPassword = validator.isStrongPassword(password);
+  const isValidPassword = validator.isStrongPassword(password, {
+    minLength: 8,
+    minNumbers: 1,
+    minSymbols: 1,
+    minLowercase: 0,
+    minUppercase: 0,
+  });
+
   if (!isValidPassword) {
-    return res
-      .status(400)
-      .json({
-        error:
-          "Password not strong enough. A strong password is minimum 8 characters long containing at least 1 lower case character, 1 upper case character, 1 number and 1 special character each.",
-      });
+    return res.status(400).json({
+      error:
+        "Password not strong enough. A strong password is minimum 8 characters long containing at least 1 number and 1 special character.",
+    });
   }
 
   try {

--- a/server/src/controller/userController.js
+++ b/server/src/controller/userController.js
@@ -2,6 +2,7 @@ import User from "../models/userModel.js";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import mongoose from "mongoose";
+import validator from "validator";
 
 //TODO: improve code below with validations
 
@@ -9,6 +10,13 @@ import mongoose from "mongoose";
 const userLogin = async (req, res) => {
   try {
     const { email, password } = req.body;
+
+    // Validate the email
+    const isValidEmail = validator.isEmail(email);
+    if (!isValidEmail) {
+      return res.status(400).json({ error: "Invalid email." });
+    }
+
     const user = await User.findOne({ email: email });
     if (!user) return res.status(403).json({ msg: "User does not exist" });
 

--- a/server/src/controller/userController.js
+++ b/server/src/controller/userController.js
@@ -26,6 +26,24 @@ const userLogin = async (req, res) => {
 // Register a new user
 const userSignUp = async (req, res) => {
   const { name, email, postalCode, password, roles } = req.body;
+
+  // Validate the email
+  const isValidEmail = validator.isEmail(email);
+  if (!isValidEmail) {
+    return res.status(400).json({ error: "Invalid email." });
+  }
+
+  // Validate the password
+  const isValidPassword = validator.isStrongPassword(password);
+  if (!isValidPassword) {
+    return res
+      .status(400)
+      .json({
+        error:
+          "Password not strong enough. A strong password is minimum 8 characters long containing at least 1 lower case character, 1 upper case character, 1 number and 1 special character each.",
+      });
+  }
+
   try {
     const salt = await bcrypt.genSalt();
     const passwordHash = await bcrypt.hash(password, salt);


### PR DESCRIPTION
## PR Summary

#### ADDED
- Added `validator` as a dependency

#### CHANGED
- Changed `userLogin` controller to validate email
- Changed `userSignup` controller to validate email as well as password

## How to test 
1. In Postman, create a Post request on the following URLs -> `http://localhost:3001/user/signup` (for email, password) and `http://localhost:3001/user/login` (for email) 
2. Try invalid email and/or weak password (not containing 8 chars or without a number or special character) in the request body
