### PR TITLE
Preserve User Input on Registration and Login Errors #196

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -44,12 +44,8 @@ const Login = () => {
 
   const navigate = useNavigate();
 
-  const clearData = (shouldClearAll) => {
-    if (shouldClearAll) {
-      setLoginData({ email: "", password: "" });
-    } else {
-      setLoginData({ email: loginData.email, password: "" });
-    }
+  const clearData = () => {
+    setLoginData((prevState) => ({ ...prevState, password: "" }));
   };
 
   const handleChange = (e) => {
@@ -71,24 +67,22 @@ const Login = () => {
     setLoginPending(true);
     try {
       const responseStatus = await login(loginData);
-      
+
       if (responseStatus === 200) {
-        clearData(true);
         setLoggedIn(true);
         navigate("/");
       } else if (responseStatus === 403) {
         setLoginFailMessage("User does not exist");
-        clearData(false);
       } else if (responseStatus === 400) {
         setLoginFailMessage("Username or password is incorrect");
-        clearData(false);
-      } else {
-        clearData(false);
       }
     } catch (error) {
       console.log(error);
+    } finally {
+      clearData();
+      setLoginPending(false);
     }
-    setLoginPending(false);
+    
   };
 
   useEffect(() => {

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -44,8 +44,8 @@ const Login = () => {
 
   const navigate = useNavigate();
 
-  const clearData = (shoulClearAll) => {
-    if (shoulClearAll) {
+  const clearData = (shouldClearAll) => {
+    if (shouldClearAll) {
       setLoginData({ email: "", password: "" });
     } else {
       setLoginData({ email: loginData.email, password: "" });

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -44,8 +44,12 @@ const Login = () => {
 
   const navigate = useNavigate();
 
-  const clearData = () => {
-    setLoginData({ email: "", password: "" });
+  const clearData = (shoulClearAll) => {
+    if (shoulClearAll) {
+      setLoginData({ email: "", password: "" });
+    } else {
+      setLoginData({ email: loginData.email, password: "" });
+    }
   };
 
   const handleChange = (e) => {
@@ -67,20 +71,24 @@ const Login = () => {
     setLoginPending(true);
     try {
       const responseStatus = await login(loginData);
-
+      
       if (responseStatus === 200) {
+        clearData(true);
         setLoggedIn(true);
         navigate("/");
       } else if (responseStatus === 403) {
         setLoginFailMessage("User does not exist");
+        clearData(false);
       } else if (responseStatus === 400) {
         setLoginFailMessage("Username or password is incorrect");
+        clearData(false);
+      } else {
+        clearData(false);
       }
     } catch (error) {
       console.log(error);
     }
     setLoginPending(false);
-    clearData();
   };
 
   useEffect(() => {

--- a/client/src/components/Login/Register.js
+++ b/client/src/components/Login/Register.js
@@ -40,11 +40,19 @@ const Register = () => {
   const [err, setErr] = useState("");
   const navigate = useNavigate();
 
-  const clearData = () => {
-    setRegisterData({ name: "", email: "", password: "" });
-    setConfirmPassword("");
-    setAcceptTerms(false);
-    setErr("");
+  const clearData = (shoulClearAll) => {
+    const { name, email } = registerData;
+    if (shoulClearAll) {
+      setRegisterData({ name: "", email: "", password: "" });
+      setConfirmPassword("");
+      setAcceptTerms(false);
+      setErr("");
+    } else {
+      setRegisterData({ name, email, password: "" });
+      setConfirmPassword("");
+      setAcceptTerms(false);
+      setErr("");
+    }
   };
 
   const handleChange = (e) => {
@@ -57,6 +65,7 @@ const Register = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (confirmPassword !== registerData.password) {
+      clearData(false);
       setErr("Password does not match");
       return;
     }
@@ -67,18 +76,20 @@ const Register = () => {
     try {
       const res = await register(registerData);
       if (res.status === 201) {
+        clearData(true);
         navigate("/login");
         setRegisterSuccessMessageVisible(true);
       } else if (res.status === 400) {
+        clearData(false);
         const json = await res.json();
         setRegisterFailMessage(json.error);
+      } else {
+        clearData(false);
       }
     } catch (error) {
       console.error(error);
       setRegisterFailMessage("Something went wrong");
     }
-
-    clearData();
   };
 
   return (

--- a/client/src/components/Login/Register.js
+++ b/client/src/components/Login/Register.js
@@ -40,9 +40,9 @@ const Register = () => {
   const [err, setErr] = useState("");
   const navigate = useNavigate();
 
-  const clearData = (shoulClearAll) => {
+  const clearData = (shouldClearAll) => {
     const { name, email } = registerData;
-    if (shoulClearAll) {
+    if (shouldClearAll) {
       setRegisterData({ name: "", email: "", password: "" });
       setConfirmPassword("");
       setAcceptTerms(false);

--- a/client/src/components/Login/Register.js
+++ b/client/src/components/Login/Register.js
@@ -40,19 +40,11 @@ const Register = () => {
   const [err, setErr] = useState("");
   const navigate = useNavigate();
 
-  const clearData = (shouldClearAll) => {
-    const { name, email } = registerData;
-    if (shouldClearAll) {
-      setRegisterData({ name: "", email: "", password: "" });
-      setConfirmPassword("");
-      setAcceptTerms(false);
-      setErr("");
-    } else {
-      setRegisterData({ name, email, password: "" });
-      setConfirmPassword("");
-      setAcceptTerms(false);
-      setErr("");
-    }
+  const clearData = () => {
+    setRegisterData((prevState) => ({ ...prevState, password: "" }));
+    setConfirmPassword("");
+    setAcceptTerms(false);
+    setErr("");
   };
 
   const handleChange = (e) => {
@@ -65,7 +57,7 @@ const Register = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (confirmPassword !== registerData.password) {
-      clearData(false);
+      clearData();
       setErr("Password does not match");
       return;
     }
@@ -76,19 +68,17 @@ const Register = () => {
     try {
       const res = await register(registerData);
       if (res.status === 201) {
-        clearData(true);
         navigate("/login");
         setRegisterSuccessMessageVisible(true);
       } else if (res.status === 400) {
-        clearData(false);
         const json = await res.json();
         setRegisterFailMessage(json.error);
-      } else {
-        clearData(false);
       }
     } catch (error) {
       console.error(error);
       setRegisterFailMessage("Something went wrong");
+    } finally {
+      clearData();
     }
   };
 


### PR DESCRIPTION
This commit addresses issue #196 by modifying the registration and login processes to preserve user input in case of errors. Now, when a registration or login attempt fails, the entered input values are retained so that users don't have to re-enter them. This enhances the user experience and reduces frustration when encountering errors during the registration and login workflows.