### PR TITLE
Update Mock API URL

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,4 @@
-EARTH911_BASE_URL=https://mockapi-earth911-ecohabit.up.railway.app
+EARTH911_BASE_URL=https://mockapi-earth911.ecohabit.org
 EARTH911_API_KEY=dummykey
 MONGODB_URI=mongodb://127.0.0.1:27017/ecohabit
 JWT_SECRET=jwtsecret


### PR DESCRIPTION
fixes #235 
i have updated Mock API URL in .env.example
![image](https://github.com/lugenx/ecohabit/assets/126584837/daa846c0-1b4c-406e-9754-a605b018e10f)
