### PR TITLE
fixed errors in earth911 mock APIs

### DIFF
--- a/mockapi-earth911/methods/getPostalData.js
+++ b/mockapi-earth911/methods/getPostalData.js
@@ -1,11 +1,11 @@
 import express from "express";
 import { fetchData } from "../functions/fetch-data.js";
-import {} from "dotenv/config";
+import { } from "dotenv/config";
 const router = express.Router();
 
 router.get("/", async (req, res) => {
   if (req.query.api_key !== "dummykey") {
-    res.send({ err: "invalid key" });
+    return res.send({ err: "invalid key" });
   }
   const country = req.query.country;
   const postalCode = req.query.postal_code;


### PR DESCRIPTION
fixes #224 
I have fixed errors in earth911 mock APIs
updated res.send({ err: "invalid key" })to return res.send({ err: "invalid key" });


![image](https://github.com/lugenx/ecohabit/assets/126584837/1d2a0d5e-beca-4b3b-bcec-a9ee5f9c70c8)
